### PR TITLE
Revert use of class static keyword pending support by Safari. Use pac…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/parser.js
+++ b/parser.js
@@ -1,4 +1,6 @@
 const MAX_DEPTH = 1000;
+const TERMINAL = 'Terminal';
+
 
 /**
  * A grammar is made of a set of rules.  A rule may be one of: RegExp,
@@ -14,7 +16,6 @@ const MAX_DEPTH = 1000;
  */
 export default class Parser {
 
-  static Terminal = 'Terminal';
 
   /**
    * @param inputString String to parse.
@@ -39,7 +40,7 @@ export default class Parser {
     if (grammar == null || stateName == null) {
       throw new Error('Neither grammar nor stateName may be null');
     }
-    if (stateName == Parser.Terminal) {
+    if (stateName == TERMINAL) {
       return 0;
     }
     const state = grammar[stateName];

--- a/parser_test.js
+++ b/parser_test.js
@@ -1,5 +1,5 @@
-import Testing from './lib/testing.js/testing.mjs';
-import Parser from './parser.mjs';
+import Testing from './lib/testing.js/testing.js';
+import Parser from './parser.js';
 
 const tests = new Testing();
 


### PR DESCRIPTION
…kage.json to signal es6 modules instead of "mjs" extension.